### PR TITLE
PRACT-35 Ensure Mentor Review of PR with CODEOWNERS File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @nikkigraybeal @ddigioia3 @erhaneth


### PR DESCRIPTION
Adding this CODEOWNERS File Should Ensure Students can't merge without approval from a mentor.