### PR TITLE
Pract 64/add favorite decks to api

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,8 @@ const mainRouter = require('./routes/mainRouter.js');
 const userRouter = require('./routes/User.js');
 const flashcardsRouter = require('./routes/Flashcards.js');
 const allUnauthFlashcardsRouter = require('./routes/flashcardsAllUnauth.js');
+const decksRouter = require('./routes/Decks.js');
+const allUnauthDecksRouter = require('./routes/decksAllUnauth');
 
 // middleware
 app.use(cors());
@@ -26,6 +28,8 @@ app.use(cookieParser());
 app.use('/api/v1', mainRouter);
 app.use('/api/v1/user', userRouter);
 app.use('/api/v1/flashcard', authenticateUser, flashcardsRouter);
+app.use('/api/v1/deck', authenticateUser, decksRouter);
 app.use('/api/v1/flashcardsAll', allUnauthFlashcardsRouter);
+app.use('/api/v1/decksAll', allUnauthDecksRouter);
 
 module.exports = app;

--- a/src/controllers/Decks.js
+++ b/src/controllers/Decks.js
@@ -1,4 +1,5 @@
 const Flashcard = require('../models/Flashcard');
+const User = require('../models/User');
 const Deck = require('../models/Deck');
 const { StatusCodes } = require('http-status-codes');
 
@@ -33,6 +34,8 @@ const getUserDecks = async (req, res) => {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
 
+    const user = await User.getById(req.user.userId);
+
     try {
         const offset = (page -1) * limit;
         const totalDecks = await Deck.countDocuments({ createdBy: req.user.userId });
@@ -40,6 +43,12 @@ const getUserDecks = async (req, res) => {
             .sort('createdAt')
             .skip(offset)
             .limit(limit);
+
+            // this is a decorator
+            const usersFavorites = user.favorite_decks;
+            for (let deck in decks) {
+                deck.isFavorite = usersFavorites.contain(deck.id)
+            }
 
         res.status(StatusCodes.OK).json({
             decks,

--- a/src/controllers/Decks.js
+++ b/src/controllers/Decks.js
@@ -1,0 +1,157 @@
+const Flashcard = require('../models/Flashcard');
+const Deck = require('../models/Deck');
+const { StatusCodes } = require('http-status-codes');
+
+// get all decks by unauthenticated users
+const getAllDecks = async (req, res) => {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
+
+    try {
+        const offset = (page -1) * limit;
+        const totalDecks = await Deck.countDocuments({});
+        const decks = await Deck.find({})
+            .sort('createdAt')
+            .skip(offset)
+            .limit(limit);
+
+        res.status(StatusCodes.OK).json({
+            decks,
+            currentPage: page,
+            totalPages: Math.ceil(totalDecks / limit),
+            totalItems: totalDecks,
+        });
+
+    } catch (error) {
+        console.error(error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ msg: 'Internal server error'});
+    }
+};
+
+// get all user decks
+const getUserDecks = async (req, res) => {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
+
+    try {
+        const offset = (page -1) * limit;
+        const totalDecks = await Deck.countDocuments({ createdBy: req.user.userId });
+        const decks = await Deck.find({ createdBy: req.user.userId })
+            .sort('createdAt')
+            .skip(offset)
+            .limit(limit);
+
+        res.status(StatusCodes.OK).json({
+            decks,
+            currentPage: page,
+            totalPages: Math.ceil(totalDecks / limit),
+            totalItems: totalDecks,
+        });
+
+    } catch (error) {
+        console.error(error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ msg: 'Internal server error'});
+    }
+};
+
+// get one deck for an auth user
+const getDeck = async (req, res) => {
+    const {
+        user: { userId },
+        params: { id: deckId }
+    } = req;
+
+    try {
+        const deck = await Deck.findOne({
+            _id: deckId, createdBy: userId
+        });
+
+        if (!deck) {
+            return res.status(StatusCodes.NOT_FOUND).json({ msg: `No deck with id ${deckId}` })
+        }
+
+        res.status(StatusCodes.OK).json({ deck });
+
+    } catch (error) {
+        console.error(error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ msg: 'Internal server error'});
+    }
+};
+
+// create deck according to the schema
+const createDeck = async (req, res) => {
+    req.body.createdBy = req.user.userId;
+    const deck = await Deck.create(req.body);
+    res.status(StatusCodes.CREATED).json({ deck });
+};
+
+// update deck
+const updateDeck = async (req, res) => {
+    const {
+        body: { title, isPublic, createdBy, flashcards },
+        user: { userId },
+        params: { id: deckId }
+    } = req;
+
+    const updatedFields = {};
+
+    if (title !== undefined) {
+        updatedFields.title = title;
+    }
+
+    if (isPublic !== undefined) {
+        updatedFields.isPublic = isPublic;
+    }
+
+    if (flashcards !== undefined) {
+        updatedFields.flashcards = flashcards;
+    }
+
+    if (Object.keys(updatedFields).length === 0) {
+        return res.status(400).json({ msg: 'No fields to update' })
+    }
+
+    try {
+        const deck = await Deck.findOneAndUpdate(
+            { _id: deckId, createdBy: userId },
+            { $set: updatedFields },
+            { new: true, runValidators: true }
+        );
+
+        if (!deck) {
+            return res.status(404).json({ msg: `No deck with id ${deckId}` });
+        }
+
+        res.status(StatusCodes.OK).json({ deck });
+    } catch (error) {
+        console.error(error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ msg: 'Internal server error' });
+    }
+};
+
+// delete deck
+const deleteDeck = async (req, res) => {
+    const {
+        user: { userId },
+        params: { id: deckId }
+    } = req;
+
+    const deck = await Deck.findOneAndDelete(
+        { _id: deckId, createdBy: userId }
+    );
+
+    if (!deck) {
+        return res.status(StatusCodes.NOT_FOUND).json({ msg: `No deck with id ${deckId}` });
+    };
+
+    res.status(StatusCodes.OK).json({ msg: 'Deck deleted' });
+};
+
+module.exports = {
+    getAllDecks,
+    getUserDecks,
+    getDeck,
+    createDeck,
+    updateDeck,
+    deleteDeck
+}

--- a/src/controllers/Decks.js
+++ b/src/controllers/Decks.js
@@ -1,5 +1,5 @@
 const Flashcard = require('../models/Flashcard');
-const User = require('../models/User');
+const User = require('../controllers/User');
 const Deck = require('../models/Deck');
 const { StatusCodes } = require('http-status-codes');
 
@@ -46,8 +46,8 @@ const getUserDecks = async (req, res) => {
 
             // this is a decorator
             const usersFavorites = user.favorite_decks;
-            for (let deck in decks) {
-                deck.isFavorite = usersFavorites.contain(deck.id)
+            for (let deck of decks) {
+                deck.isFavorite = usersFavorites.includes(deck._id);
             }
 
         res.status(StatusCodes.OK).json({

--- a/src/controllers/Decks.js
+++ b/src/controllers/Decks.js
@@ -88,15 +88,19 @@ const createDeck = async (req, res) => {
 // update deck
 const updateDeck = async (req, res) => {
     const {
-        body: { title, isPublic, createdBy, flashcards },
+        body: { topic, subtopic, isPublic, createdBy, flashcards },
         user: { userId },
         params: { id: deckId }
     } = req;
 
     const updatedFields = {};
 
-    if (title !== undefined) {
-        updatedFields.title = title;
+    if (topic !== undefined) {
+        updatedFields.topic = topic;
+    }
+
+    if (subtopic !== undefined) {
+        updatedFields.subtopic = subtopic;
     }
 
     if (isPublic !== undefined) {

--- a/src/controllers/Flashcards.js
+++ b/src/controllers/Flashcards.js
@@ -1,6 +1,7 @@
 const Flashcard = require('../models/Flashcard');
 const { StatusCodes } = require('http-status-codes');
 
+// GET all flashcards for any unauthenticated user
 const getAllFlashcards = async (req, res) => {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
@@ -25,6 +26,7 @@ const getAllFlashcards = async (req, res) => {
     }
 };
 
+// GET the flashcards of a specific user (for a logged in user)
 const getUserFlashcards = async (req, res) => {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
@@ -49,6 +51,15 @@ const getUserFlashcards = async (req, res) => {
     }
 };
 
+// get the flashcards that appertain to a specific deck
+const getFlashcardForDeck = async (req, res) => {
+
+    req.body.createdBy = req.user.userId;
+    const flashcards = await Flashcard.find({ createdBy: req.user.userId, deck: req.id }).sort('createdAt');
+    res.status(StatusCodes.CREATED).json({ flashcards, count: flashcards.length });
+};
+
+// get one flashcard
 const getFlashcard = async (req, res) => {
     const { 
         user: { userId }, 
@@ -73,6 +84,7 @@ const getFlashcard = async (req, res) => {
     
 };
 
+// create flashcard according to the schema
 const createFlashcard = async (req, res) => {
 
     req.body.createdBy = req.user.userId;
@@ -80,9 +92,10 @@ const createFlashcard = async (req, res) => {
     res.status(StatusCodes.CREATED).json({ flashcard });
 };
 
+// update flashcard
 const updateFlashcard = async (req, res) => {
     const {
-        body: { topic, question, answer, createdBy },
+        body: { topic, question, answer, resources, hint, createdBy },
         user: { userId },
         params: { id: flashcardId }
     } = req;
@@ -99,6 +112,14 @@ const updateFlashcard = async (req, res) => {
 
     if (answer != undefined) {
         updatedFields.answer = answer;
+    }
+
+    if (resources != undefined) {
+        updatedFields.resources = resources;
+    }
+
+    if (hint != undefined) {
+        updatedFields.hint = hint;
     }
 
     if (Object.keys(updatedFields).length === 0) {
@@ -118,6 +139,7 @@ const updateFlashcard = async (req, res) => {
     res.status(StatusCodes.OK).json({ flashcard });
 }
 
+// delete flashcard
 const deleteFlashcard = async (req, res) => {
     const {
         user: { userId },
@@ -138,8 +160,9 @@ const deleteFlashcard = async (req, res) => {
 module.exports = {
     getAllFlashcards,
     getUserFlashcards,
+    getFlashcardForDeck,
     getFlashcard,
     createFlashcard,
     updateFlashcard,
-    deleteFlashcard
+    deleteFlashcard,
 }

--- a/src/controllers/Flashcards.js
+++ b/src/controllers/Flashcards.js
@@ -113,16 +113,12 @@ const createFlashcard = async (req, res) => {
 // update flashcard
 const updateFlashcard = async (req, res) => {
     const {
-        body: { topic, question, answer, resources, hint, createdBy },
+        body: { question, answer, resources, hint, createdBy },
         user: { userId },
         params: { id: flashcardId }
     } = req;
 
     const updatedFields = {};
-
-    if (topic !== undefined) {
-        updatedFields.topic = topic;
-    }
 
     if (question !== undefined) {
         updatedFields.question = question;

--- a/src/controllers/User.js
+++ b/src/controllers/User.js
@@ -1,4 +1,5 @@
 const User = require('../models/User');
+const Deck = require('../models/Deck');
 const { createJWT } = require('./auth');
 const jwt = require('jsonwebtoken');
 const { StatusCodes } = require('http-status-codes');
@@ -126,6 +127,33 @@ const login = async (req, res) => {
     }
 };
 
+// getFavoriteDecks
+const getFavoriteDecks = async (req, res) => {
+    try {
+        const userId = req.params.id; 
+
+        if (!userId) {
+            return res.status(StatusCodes.BAD_REQUEST).json({ message: 'Invalid user ID' });
+        }
+
+        const user = await User.findById(userId);
+
+        if (!user) {
+            return res.status(StatusCodes.NOT_FOUND).json({ message: 'User not found' });
+        }
+
+        const favoriteDeckIds = user.favorite_decks;
+
+        const favoriteDecks = await Deck.find({ _id: { $in: favoriteDeckIds } });
+
+        res.status(StatusCodes.OK).json({ favoriteDecks });
+
+    } catch (error) {
+        console.error(error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: 'Internal server error' });
+    }
+};
+
 const logout = async (req, res) => {
     return res
         .clearCookie('token')
@@ -133,4 +161,4 @@ const logout = async (req, res) => {
         .json({ msg: 'Successfully logged out' })
 }
 
-module.exports = { getById, login, register, logout };
+module.exports = { getById, login, register, getFavoriteDecks, logout };

--- a/src/controllers/User.js
+++ b/src/controllers/User.js
@@ -10,7 +10,11 @@ const getById = async (req, res) => {
         // extract userId from the route params
         const userId = req.params.id;
 
-        // fetch the user by Id
+        // check if userId is defined
+        if (!userId) {
+            return res.status(400).json({ message: 'Invalid user ID' });
+        }
+        // fetch the user by id
         const user = await User.findById(userId);
 
         // check if the user exists

--- a/src/controllers/User.js
+++ b/src/controllers/User.js
@@ -64,7 +64,7 @@ const register = async (req, res) => {
             firstName: newUser.firstName,
             lastName: newUser.lastName,
             role: newUser.role 
-        }, token });
+        }, userId:newUser._id, token });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Internal server error' });
@@ -114,8 +114,7 @@ const login = async (req, res) => {
                 firstName: user.firstName,
                 lastName: user.lastName,
                 role: user.role
-            }, 
-        token });
+            }, userId:user._id, token });
 
     } catch (error) {
         console.error(error);

--- a/src/controllers/User.js
+++ b/src/controllers/User.js
@@ -57,7 +57,14 @@ const register = async (req, res) => {
         // generate a JWT token for the newly registered user
         const token = createJWT(newUser);
 
-        res.status(StatusCodes.CREATED).json({ user: { username: newUser.username }, token });
+        res.status(StatusCodes.CREATED).json({ user: { 
+            username: newUser.username,
+            createdBy: newUser.createdBy,
+            email: newUser.email,
+            firstName: newUser.firstName,
+            lastName: newUser.lastName,
+            role: newUser.role 
+        }, token });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Internal server error' });
@@ -99,8 +106,16 @@ const login = async (req, res) => {
         );
 
         // Send the JWT token in the response
-        // res.status(200).json({ token });
-        res.status(200).json({ user: { username: user.username }, token });
+        res.status(200).json({ 
+            user: { 
+                username: user.username,
+                createdBy: user.createdBy,
+                email: user.email,
+                firstName: user.firstName,
+                lastName: user.lastName,
+                role: user.role
+            }, 
+        token });
 
     } catch (error) {
         console.error(error);

--- a/src/models/Deck.js
+++ b/src/models/Deck.js
@@ -8,7 +8,6 @@ const deckSchema = new mongoose.Schema({
     },
     subtopic: {
         type: String,
-        required: [true, 'Subtopic cannot be blank'],
         maxlength: 300,
     },
     isPublic: {

--- a/src/models/Deck.js
+++ b/src/models/Deck.js
@@ -1,9 +1,14 @@
 const mongoose = require('mongoose');
 
 const deckSchema = new mongoose.Schema({
-    title: {
+    topic: {
         type: String,
-        required: [true, 'Title cannot be blank'],
+        required: [true, 'Topic cannot be blank'],
+        maxlength: 300,
+    },
+    subtopic: {
+        type: String,
+        required: [true, 'Subtopic cannot be blank'],
         maxlength: 300,
     },
     isPublic: {

--- a/src/models/Deck.js
+++ b/src/models/Deck.js
@@ -1,6 +1,24 @@
+const mongoose = require('mongoose');
 
+const deckSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        required: [true, 'Title cannot be blank'],
+        maxlength: 300,
+    },
+    isPublic: {
+        type: Boolean,
+        default: false,
+    },
+    createdBy: {
+        type: mongoose.Types.ObjectId,
+        ref: 'User',
+        required: true,
+    },
+    flashcards: [{
+        type: mongoose.Types.ObjectId,
+        ref: 'Flashcard',
+    }],
+}, { timestamps: true });
 
-// deck: {
-//     type: mongoose.Types.ObjectId,
-//     ref: 'Deck',
-// },
+module.exports = mongoose.model('Deck', deckSchema);

--- a/src/models/Deck.js
+++ b/src/models/Deck.js
@@ -1,0 +1,6 @@
+
+
+// deck: {
+//     type: mongoose.Types.ObjectId,
+//     ref: 'Deck',
+// },

--- a/src/models/Flashcard.js
+++ b/src/models/Flashcard.js
@@ -1,11 +1,6 @@
 const mongoose = require('mongoose');
 
 const flashcardSchema = new mongoose.Schema({
-    topic: {
-        type: String,
-        required: [true, 'Topic field cannot be blank'],
-        enum: ['Ruby on Rails', 'Node.js', 'React', 'HTML', 'CSS', 'Express'],
-    },
     question: {
         type: String,
         required: [true, 'Question field cannot be blank'],

--- a/src/models/Flashcard.js
+++ b/src/models/Flashcard.js
@@ -3,36 +3,36 @@ const mongoose = require('mongoose');
 const flashcardSchema = new mongoose.Schema({
     topic: {
         type: String,
-        required: [true, 'Cannot be blank'],
+        required: [true, 'Topic field cannot be blank'],
         enum: ['Ruby on Rails', 'Node.js', 'React', 'HTML', 'CSS', 'Express'],
     },
     question: {
         type: String,
-        required: [true, 'Cannot be blank'],
+        required: [true, 'Question field cannot be blank'],
         maxlength: 500,
     },
     answer: {
         type: String,
-        required: [true, 'Cannot be blank'],
+        required: [true, 'Answer field cannot be blank'],
         maxlength: 500,
     },
     resources: {
         type: String,
-        required: [false],
         maxlength: 500,
     },
     hint: {
         type: String,
-        required: [false],
         maxlength: 500,
     },
-    decks: {
-        type: [String],
-        maxlength: 100,
-    },
+    deck: {
+        type: mongoose.Types.ObjectId,
+        ref: 'Deck',
+        required: true,
+},
     createdBy: {
         type: mongoose.Types.ObjectId,
         ref: 'User',
+        required: [true],
     }
 }, { timestamps: true });
 

--- a/src/models/Flashcard.js
+++ b/src/models/Flashcard.js
@@ -5,7 +5,6 @@ const flashcardSchema = new mongoose.Schema({
         type: String,
         required: [true, 'Cannot be blank'],
         enum: ['Ruby on Rails', 'Node.js', 'React', 'HTML', 'CSS', 'Express'],
-        maxlength: 150,
     },
     question: {
         type: String,
@@ -16,6 +15,20 @@ const flashcardSchema = new mongoose.Schema({
         type: String,
         required: [true, 'Cannot be blank'],
         maxlength: 500,
+    },
+    resources: {
+        type: String,
+        required: [false],
+        maxlength: 500,
+    },
+    hint: {
+        type: String,
+        required: [false],
+        maxlength: 500,
+    },
+    decks: {
+        type: [String],
+        maxlength: 100,
     },
     createdBy: {
         type: mongoose.Types.ObjectId,

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -35,6 +35,10 @@ const userSchema = new mongoose.Schema({
         type: String,
         required: [true, 'Cannot be blank'],
     },
+    favorite_decks: {
+        type: [mongoose.Types.ObjectId],
+        ref: 'Deck',
+    }
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -10,13 +10,13 @@ const userSchema = new mongoose.Schema({
     },
     firstName: {
         type: String,
-        required: [true, 'Cannot be blank'],
+        required: [false, 'Cannot be blank'],
         match: [/^[a-zA-Z0-9]+$/, 'Username is invalid'],
         maxlength: 50,
     },
     lastName: {
         type: String,
-        required: [true, 'Cannot be blank'],
+        required: [false, 'Cannot be blank'],
         match: [/^[a-zA-Z0-9]+$/, 'Username is invalid'],
         maxlength: 50,
     },

--- a/src/routes/Decks.js
+++ b/src/routes/Decks.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+    getUserDecks,
+    getDeck,
+    createDeck,
+    updateDeck,
+    deleteDeck
+} = require('../controllers/Decks');
+
+router.route('/').post(createDeck).get(getUserDecks);
+router.route('/:id').get(getDeck).delete(deleteDeck).patch(updateDeck);
+
+module.exports = router;

--- a/src/routes/User.js
+++ b/src/routes/User.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 const { login, register, getById, logout } = require('../controllers/User');
 
-router.get('/user/:id', getById);
+router.get('/:id', getById);
 router.post('/register', register);
 router.post('/login', login);
 router.post('/logout', logout);

--- a/src/routes/User.js
+++ b/src/routes/User.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 
-const { login, register, getById, logout } = require('../controllers/User');
+const { login, register, getById, getFavoriteDecks, logout } = require('../controllers/User');
 
+router.get('/:id/favorite', getFavoriteDecks);
 router.get('/:id', getById);
 router.post('/register', register);
 router.post('/login', login);

--- a/src/routes/decksAllUnauth.js
+++ b/src/routes/decksAllUnauth.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const { getAllDecks } = require('../controllers/Decks');
+
+router.route('/').get(getAllDecks);
+
+module.exports = router;


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

Added a decorator in the getUserDecks controller and added favorite_decks field in the User model to make possible for the front end to add favorite decks.
Additionally, added a new route and controller for the user favorite decks in the User routes/controllers.

## Related Issue

Added favorite_decks field for each user. Can be merged only after Pract 64/add favorite decks to api gets merged.

## Acceptance Criteria

Tested with Postman that it adds the favorite_decks field for each user.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

### After

![image](https://github.com/Code-the-Dream-School/ee-prac-team4-back/assets/105457134/bc4a7d0f-4cc7-4eef-a95a-2ae4078b51ef)

![image](https://github.com/Code-the-Dream-School/ee-prac-team4-back/assets/105457134/db71b90d-1ff6-484b-9a4d-14200b7b6548)


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

© 2022 GitHub, Inc.
Terms
Privacy
Security
Status
